### PR TITLE
Remove unnecessary semicolon in usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ class Demo extends Component {
             ],
             onSelect: item => {
                 // `item` = { label: 'First', value: 'first' }
-            };,
+            },
         };
 
         return <QuickSearch {...props} />


### PR DESCRIPTION
I found an unnecessary semicolon in usage section in README.